### PR TITLE
Add the ability to fall back from a specified file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ matrix:
   allow_failures:
     - rust: nightly
 script:
-  - cargo build --verbose --all -- --test-threads 1
+  - cargo build --verbose --all
   - cargo test --verbose --all -- --test-threads 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ matrix:
   allow_failures:
     - rust: nightly
 script:
-  - cargo build --verbose --all
+  - cargo build --verbose
   - cargo test --verbose --all -- --test-threads 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ matrix:
   allow_failures:
     - rust: nightly
 script:
-  - cargo build --verbose --all
-  - cargo test --verbose --all
+  - cargo build --verbose --all -- --test-threads 1
+  - cargo test --verbose --all -- --test-threads 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "loadconf"
 description = "Library for loading configuration files quickly."
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Curtis Millar <curtis@curtism.me>"]
 repository = "https://github.com/xurtis/loadconf"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,14 +105,20 @@ pub trait Load: Sized {
 
     /// Loads the configuration from the given path or falls back to search if
     /// the path is None. Errors if file can't be read or deserialized.
-    fn try_fallback_load<S: AsRef<str>, P: AsRef<Path>>(filename: S, path: Option<P>) -> Result<Self, Error>;
+    fn try_fallback_load<S: AsRef<str>, P: AsRef<Path>>(
+        filename: S,
+        path: Option<P>,
+    ) -> Result<Self, Error>;
 }
 
 impl<C> Load for C
 where
     C: Default + DeserializeOwned,
 {
-    fn try_fallback_load<S: AsRef<str>, P: AsRef<Path>>(filename: S, path: Option<P>) -> Result<C, Error> {
+    fn try_fallback_load<S: AsRef<str>, P: AsRef<Path>>(
+        filename: S,
+        path: Option<P>,
+    ) -> Result<C, Error> {
         if let Some(path) = path {
             read_from_file(path.as_ref())
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,25 +75,46 @@ pub trait Load: Sized {
     ///
     /// This will panic if there are any issues reading or deserializing the file.
     /// To catch these errors, use `try_load` instead.
-    fn load(filename: &str) -> Self {
+    fn load<S: AsRef<str>>(filename: S) -> Self {
         Load::try_load(filename).expect("Error reading configuration from file")
     }
 
     /// Find a configuration file and load the contents, falling back to
     /// the default. Errors if file can't be read or deserialized.
-    fn try_load(filename: &str) -> Result<Self, Error>;
+    fn try_load<S: AsRef<str>>(filename: S) -> Result<Self, Error> {
+        Load::try_fallback_load(filename, None)
+    }
+
+    /// Loads the configuration from the given path or falls back to search if
+    /// the path is None.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if there are any issues reading or deserializing the file.
+    /// To catch these errors, use `try_load` instead.
+    fn fallback_load<S: AsRef<str>>(filename: S, path: Option<S>) -> Self {
+        Load::try_fallback_load(filename, path).expect("Error reading configuration from file")
+    }
+
+    /// Loads the configuration from the given path or falls back to search if
+    /// the path is None. Errors if file can't be read or deserialized.
+    fn try_fallback_load<S: AsRef<str>>(filename: S, path: Option<S>) -> Result<Self, Error>;
 }
 
 impl<C> Load for C
 where
     C: Default + DeserializeOwned,
 {
-    fn try_load(filename: &str) -> Result<C, Error> {
-        let paths = path_list(filename);
+    fn try_fallback_load<S: AsRef<str>>(filename: S, path: Option<S>) -> Result<C, Error> {
+        if let Some(path) = path {
+            read_from_file(path.as_ref())
+        } else {
+            let paths = path_list(filename.as_ref());
 
-        match paths.iter().find(|p| p.exists()) {
-            Some(path) => read_from_file(path),
-            None => Ok(Default::default()),
+            match paths.iter().find(|p| p.exists()) {
+                Some(path) => read_from_file(path),
+                None => Ok(Default::default()),
+            }
         }
     }
 }
@@ -240,6 +261,36 @@ mod test {
 
         // Load the file
         let config = Config::load("testcfg");
+        let expected = Config { var: "Test configuration file".to_string() };
+        assert_eq!(config, expected);
+    }
+
+    /// Test load configuration from a file specified directly.
+    #[test]
+    fn specified_file_test() {
+        use std::env::set_current_dir;
+        use std::fs::OpenOptions;
+        use std::io::Write;
+        use super::Load;
+        use tempdir::TempDir;
+
+        // Change into temporary testi directory
+        let temp_dir = TempDir::new("loadcfg-test")
+            .expect("Could not create temporary directory for test");
+        set_current_dir(temp_dir.path())
+            .expect("Could not change into temporary directory for test");
+
+        // Write the test configuration file.
+        OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open("given-config.toml")
+            .expect("Couldn't open test configuration file.")
+            .write_all("var = \"Test configuration file\"\n".as_bytes())
+            .expect("Couldn't write test configuration file.");
+
+        // Load the file
+        let config = Config::fallback_load("testcfg", Some("given-config.toml"));
         let expected = Config { var: "Test configuration file".to_string() };
         assert_eq!(config, expected);
     }


### PR DESCRIPTION
This allows a file path to be passed in from the command line.
If it is passed in, it is read instead of doing the traversal.